### PR TITLE
Modal 오류 해결

### DIFF
--- a/src/components/units/main/main.presenter.tsx
+++ b/src/components/units/main/main.presenter.tsx
@@ -3,7 +3,7 @@ import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import styled from "@emotion/styled";
-import { LeftOutlined, RightOutlined } from "@ant-design/icons";
+
 import Modal from "react-modal";
 import { useState } from "react";
 
@@ -149,15 +149,22 @@ export default function MainPageUI(): JSX.Element {
     ),
   };
 
+  const [isOpenList, setIsOpenList] = useState(
+    Array(subBannerItems.length).fill(false)
+  );
+
+  const onClickImg = (index: number) => {
+    const updatedIsOpenList = [...isOpenList];
+    updatedIsOpenList[index] = true;
+    setIsOpenList(updatedIsOpenList);
+  };
+  const onClickCancel = (index: number) => {
+    const updatedIsOpenList = [...isOpenList];
+    updatedIsOpenList[index] = false;
+    setIsOpenList(updatedIsOpenList);
+  };
+
   const [isOpen, setIsOpen] = useState(false);
-
-  const onClickImg = () => {
-    setIsOpen(true);
-  };
-
-  const onClickCancel = () => {
-    setIsOpen(false);
-  };
 
   return (
     <S.Wrapper>
@@ -173,14 +180,14 @@ export default function MainPageUI(): JSX.Element {
       <S.title>액션</S.title>
       <S.SubBannerWrapper>
         <StyledSlider {...subsettings}>
-          {subBannerItems.map((el) => (
+          {subBannerItems.map((el, index) => (
             <>
-              <S.ImgBox key={el.name} onClick={onClickImg}>
+              <S.ImgBox key={el.name} onClick={() => onClickImg(index)}>
                 <S.SubSliderItem src={el.poster_path} />
               </S.ImgBox>
               <Modal
-                isOpen={isOpen}
-                onRequestClose={() => setIsOpen(false)}
+                isOpen={isOpenList[index]}
+                onRequestClose={() => onClickCancel(index)}
                 style={S.customModalStyles}
                 ariaHideApp={false}
                 contentLabel="Pop up Message"
@@ -191,7 +198,7 @@ export default function MainPageUI(): JSX.Element {
 
                   <S.ModalCancel
                     src="/img/icon/cancel.png"
-                    onClick={onClickCancel}
+                    onClick={() => onClickCancel(index)}
                   />
                   <h2>{el.overview}</h2>
                 </S.ModalWrapper>

--- a/src/components/units/main/main.styles.ts
+++ b/src/components/units/main/main.styles.ts
@@ -76,7 +76,7 @@ export const ModalCancel = styled.img`
 
 export const customModalStyles: ReactModal.Styles = {
   overlay: {
-    backgroundColor: "rgba(52,52,52,0.05)",
+    backgroundColor: "rgba(52,52,52,0.3)",
     width: "100%",
     height: "100vh",
     zIndex: "10",


### PR DESCRIPTION
- 이미지 클릭하여 모달클릭시  어떤 이미지를 클릭하던 같은 이미지와 설명이 뜨던 문제를 해결
- 이미지마다 인덱스값을 주고 그걸 스테이트로 관리하여 선택된 이미지의 인덱스값을넘겨주어 모달창에서 보여줄 이미지와 overview설명을 선택하도록하여 해결함