### PR TITLE
회원 탈퇴 버튼 추가

### DIFF
--- a/src/components/units/login/login_complete.tsx
+++ b/src/components/units/login/login_complete.tsx
@@ -14,6 +14,106 @@ export default function LoginCompletePage(): JSX.Element {
     router.push("/user/edit");
   };
 
+  const onClickQuit = () => {
+    // IMAD 유저 삭제부
+    if (userData?.data.auth_provider === "IMAD") {
+      const DELIMADUSER = async () => {
+        try {
+          const response = await axios.delete("https://ncookie.site/api/user", {
+            headers: {
+              Authorization: `Bearer ${getCookie("Authorization")}`,
+            },
+          });
+          if (response.status === 200) {
+          }
+        } catch (error) {
+          console.error("Error delete user", error);
+        }
+      };
+      DELIMADUSER();
+    }
+    // KAKAO 유저 삭제부
+    else if (userData?.data.auth_provider === "KAKAO") {
+      const DELKAKAOUSER = async () => {
+        try {
+          const response = await axios.delete(
+            "https://ncookie.site/api/oauth2/revoke/kakao",
+            {
+              headers: {
+                Authorization: `Bearer ${getCookie("Authorization")}`,
+              },
+            }
+          );
+          if (response.status === 200) {
+          }
+        } catch (error) {
+          console.error("Error delete user", error);
+        }
+      };
+      DELKAKAOUSER();
+    }
+    // NAVER 유저 삭제부
+    else if (userData?.data.auth_provider === "NAVER") {
+      const DELNAVERUSER = async () => {
+        try {
+          const response = await axios.delete(
+            "https://ncookie.site/api/oauth2/revoke/naver",
+            {
+              headers: {
+                Authorization: `Bearer ${getCookie("Authorization")}`,
+              },
+            }
+          );
+          if (response.status === 200) {
+          }
+        } catch (error) {
+          console.error("Error delete user", error);
+        }
+      };
+      DELNAVERUSER();
+    }
+    // GOOGLE 유저 삭제부
+    else if (userData?.data.auth_provider === "GOOGLE") {
+      const DELGOOGLEUSER = async () => {
+        try {
+          const response = await axios.delete(
+            "https://ncookie.site/api/oauth2/revoke/google",
+            {
+              headers: {
+                Authorization: `Bearer ${getCookie("Authorization")}`,
+              },
+            }
+          );
+          if (response.status === 200) {
+          }
+        } catch (error) {
+          console.error("Error delete user", error);
+        }
+      };
+      DELGOOGLEUSER();
+    }
+    // APPLE 유저 삭제부
+    else if (userData?.data.auth_provider === "APPLE") {
+      const DELAPPLEUSER = async () => {
+        try {
+          const response = await axios.delete(
+            "https://ncookie.site/api/oauth2/revoke/APPLE",
+            {
+              headers: {
+                Authorization: `Bearer ${getCookie("Authorization")}`,
+              },
+            }
+          );
+          if (response.status === 200) {
+          }
+        } catch (error) {
+          console.error("Error delete user", error);
+        }
+      };
+      DELAPPLEUSER();
+    }
+  };
+
   const eventHandler = () => {
     setEvent(!event);
   };
@@ -46,6 +146,7 @@ export default function LoginCompletePage(): JSX.Element {
       <div>email : {userData ? userData.data.email : "???"}</div>
       <button onClick={eventHandler}>새로고침</button>
       <button onClick={onClickEdit}>회원정보수정</button>
+      <button onClick={onClickQuit}>회원탈퇴</button>
     </>
   );
 }


### PR DESCRIPTION
- 일단 추가 인증없이 회원탈퇴기능 작동 테스트
- 회원탈퇴가 소셜 로그인종류별로 api 분류가 되어있기에 user 페이지에서 패치 해온 유저정보의 auth_provider 를 보고 회원종류를 판별 각각의 api 를 작동시킴