### PR TITLE
소셜로그인 성공 실패 페이지 분리

### DIFF
--- a/pages/oauth2/redirect/fail/index.tsx
+++ b/pages/oauth2/redirect/fail/index.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "next/router";
+
+export default function RedirectFailPage(): JSX.Element {
+  const router = useRouter();
+
+  const onClickReturn = () => {
+    router.push("/login");
+  };
+
+  return (
+    <>
+      <h1>!!소셜로그인 실패!!</h1>
+      <h1>로그인을 다시 시도해주세요</h1>
+      <button onClick={onClickReturn}>로그인 화면으로 돌아가기</button>
+    </>
+  );
+}

--- a/pages/oauth2/redirect/success/index.tsx
+++ b/pages/oauth2/redirect/success/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { setCookie, getCookie } from "../../../src/commons/cookies/cookie";
+import { setCookie, getCookie } from "../../../../src/commons/cookies/cookie";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
@@ -35,7 +35,13 @@ export default function KakaoRedirect(): JSX.Element {
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
+    const refresh_token = params.get("refresh_token");
     const token = params.get("token");
+    setCookie("Authorization_refresh", refresh_token, {
+      path: "/",
+      secure: true,
+      sameSite: "none",
+    });
     setCookie("Authorization", token, {
       path: "/",
       secure: true,


### PR DESCRIPTION
- 성공과 실패 페이지를 oauth2/redirect/success&fail 로 구분함

- 소셜로그인 성공 리다이렉트 페이지에서 리프레쉬 토큰 저장 로직을 추가함 쿠키 Authorization_refresh