### PR TITLE
search 페이지에서 detail 기능추가

### DIFF
--- a/pages/search/movie/[id]/index.tsx
+++ b/pages/search/movie/[id]/index.tsx
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import SearchDetailUI from "../../../../src/components/units/search_detail/search_detail_presenter";
+import { IDetailUIProps } from "@/src/components/units/search_detail/search_detail_types";
+export default function TvDetail_Page(): JSX.Element {
+  const router = useRouter();
+  const [detail, setDetail] = useState();
+
+  const detailSearch = async () => {
+    try {
+      const detailRES = await axios.get(
+        `https://api.iimad.com/api/contents/details?id=${router.query.id}&type=movie`,
+        {
+          headers: {
+            Authorization: "GUEST",
+          },
+        }
+      );
+
+      if (detailRES.status === 200) {
+        setDetail(detailRES.data.data);
+        console.log(detail);
+      }
+    } catch (error) {
+      console.error("Error occurred while searching:", error);
+    }
+  };
+
+  useEffect(() => {
+    detailSearch();
+  }, []);
+
+  return <SearchDetailUI data={detail} />;
+}

--- a/pages/search/tv/[id]/index.tsx
+++ b/pages/search/tv/[id]/index.tsx
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import SearchDetailUI from "../../../../src/components/units/search_detail/search_detail_presenter";
+import { IDetailUIProps } from "@/src/components/units/search_detail/search_detail_types";
+export default function TvDetail_Page(): JSX.Element {
+  const router = useRouter();
+  const [detail, setDetail] = useState();
+
+  const detailSearch = async () => {
+    try {
+      const detailRES = await axios.get(
+        `https://api.iimad.com/api/contents/details?id=${router.query.id}&type=tv`,
+        {
+          headers: {
+            Authorization: "GUEST",
+          },
+        }
+      );
+
+      if (detailRES.status === 200) {
+        setDetail(detailRES.data.data);
+        console.log(detail);
+      }
+    } catch (error) {
+      console.error("Error occurred while searching:", error);
+    }
+  };
+
+  useEffect(() => {
+    detailSearch();
+  }, []);
+
+  return <SearchDetailUI data={detail} />;
+}

--- a/src/components/units/search/search_container.tsx
+++ b/src/components/units/search/search_container.tsx
@@ -1,11 +1,19 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import axios from "axios";
 import * as S from "../search/search_styles";
+import Modal from "react-modal";
+import { useRouter } from "next/router";
+
+interface IDetail {
+  poster_path: string;
+  overview: string;
+}
 
 export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [showSearch, setShowSearch] = useState(false);
+  const router = useRouter();
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
@@ -41,6 +49,10 @@ export default function SearchPage() {
     }
   };
 
+  const onClickImg = (resultId: String, media_type: String) => {
+    router.push(`/search/${media_type}/${resultId}`);
+  };
+
   return (
     <div>
       <h1>작품 검색</h1>
@@ -55,8 +67,11 @@ export default function SearchPage() {
       </form>
       {showSearch && searchResults && searchResults.length > 0 && (
         <>
-          {searchResults.map((result: any) => (
-            <div key={result.id}>
+          {searchResults.map((result: any, index) => (
+            <div
+              key={result.id}
+              onClick={() => onClickImg(result.id, result.media_type)}
+            >
               {result.poster_path && (
                 <S.ImgBox
                   src={`https://image.tmdb.org/t/p/original/${result.poster_path}`}

--- a/src/components/units/search/search_styles.ts
+++ b/src/components/units/search/search_styles.ts
@@ -6,3 +6,46 @@ export const ImgBox = styled.img`
   margin: auto;
   border-radius: 10px;
 `;
+
+export const ModalWrapper = styled.div`
+  width: 800px;
+  height: 1000px;
+`;
+
+export const ModalImg = styled.img`
+  height: 400px;
+  width: 250px;
+  margin: auto;
+  border-radius: 10px;
+`;
+
+export const ModalCancel = styled.img`
+  height: 30px;
+  width: 30px;
+`;
+
+export const customModalStyles: ReactModal.Styles = {
+  overlay: {
+    backgroundColor: "rgba(52,52,52,0.3)",
+    width: "100%",
+    height: "100vh",
+    zIndex: "10",
+    position: "fixed",
+    top: "0",
+    left: "0",
+  },
+  content: {
+    width: "800px",
+    height: "1000px",
+    zIndex: "150",
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    borderRadius: "10px",
+    boxShadow: "2px 2px 2px rgba(0, 0, 0, 0.25)",
+    backgroundColor: "white",
+    justifyContent: "center",
+    overflow: "auto",
+  },
+};

--- a/src/components/units/search_detail/search_detail_presenter.tsx
+++ b/src/components/units/search_detail/search_detail_presenter.tsx
@@ -1,0 +1,23 @@
+import { IDetailUIProps } from "./search_detail_types";
+import * as S from "./search_detail_styles";
+export default function SearchDetailUI(props: IDetailUIProps): JSX.Element {
+  return (
+    <>
+      <S.Wrapper>
+        <S.RowWrapper>
+          <div>
+            <h1>{props?.data?.name || props?.data?.title}</h1>
+            <h2>{props?.data?.contents_type}</h2>
+          </div>
+          <S.ImgBox
+            src={`https://image.tmdb.org/t/p/original/${props?.data?.poster_path}`}
+            alt="Poster"
+          />
+        </S.RowWrapper>
+
+        <span>----------------------------------------------</span>
+        <h3>{props?.data?.overview}</h3>
+      </S.Wrapper>
+    </>
+  );
+}

--- a/src/components/units/search_detail/search_detail_styles.ts
+++ b/src/components/units/search_detail/search_detail_styles.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const RowWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+export const ImgBox = styled.img`
+  height: 400px;
+  width: 250px;
+  margin: auto;
+  border-radius: 10px;
+`;

--- a/src/components/units/search_detail/search_detail_types.ts
+++ b/src/components/units/search_detail/search_detail_types.ts
@@ -1,0 +1,10 @@
+export interface IDetailUIProps {
+  data?: {
+    title: string;
+    name: string;
+    tmdb_type: string;
+    overview: string;
+    poster_path: string;
+    contents_type: string;
+  } | null;
+}


### PR DESCRIPTION
- 원래 모달로 페이지를 구성하려하였으나 데이터 전달 오류로 실패
- 새로운 페이지에서 다이나믹 라우팅을 이용해 게시물 번호의 페이지로 이동시키는 로직을 추가함
- 페이지 이동후 url에서 media_type 과 [id] 를 가져와 게시물 상세보기 api를 요청
- 이후 받아온 데이터를 화면에 뿌려주게됨