### PR TITLE
작품검색 수정

### DIFF
--- a/src/components/units/search/search_container.tsx
+++ b/src/components/units/search/search_container.tsx
@@ -19,6 +19,18 @@ export default function SearchPage() {
     setQuery(event.target.value);
   };
 
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (query) {
+      timer = setTimeout(() => {
+        search();
+      }, 500);
+    }
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [query]);
+
   const search = async () => {
     try {
       const response = await axios.get(
@@ -40,15 +52,6 @@ export default function SearchPage() {
     }
   };
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (query !== "") {
-      await search();
-    } else {
-      alert("검색어를 입력해주세요.");
-    }
-  };
-
   const onClickImg = (resultId: String, media_type: String) => {
     router.push(`/search/${media_type}/${resultId}`);
   };
@@ -56,15 +59,14 @@ export default function SearchPage() {
   return (
     <div>
       <h1>작품 검색</h1>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          value={query}
-          onChange={handleInputChange}
-          placeholder="작품명을 입력해주세요..."
-        />
-        <button type="submit">Search</button>
-      </form>
+
+      <input
+        type="text"
+        value={query}
+        onChange={handleInputChange}
+        placeholder="작품명을 입력해주세요..."
+      />
+
       {showSearch && searchResults && searchResults.length > 0 && (
         <>
           {searchResults.map((result: any, index) => (


### PR DESCRIPTION
- 작품을 검색할때 쿼리를 입력후 검색버튼을 눌러야하는 기존 로직과 다르게 검색어를 입력시 추가 버튼입력없이 검색결과가 표출되기를 희망함

- 하지만 쿼리가 변결될때마다 요청을보내게되면 단어의 구성 글자수만큼이나 요청이 가게되기 때문에 자원의 낭비가 발생한다

- 그렇기에 타이머와 useEffect를 활용해 query가 변경될때마다 타이머가 작동하게 되고 0.5sec 동안 추가입력이 있다면 타이머리셋 추가입력이 없다면 검색요청을 서버에 보내는 로직을 추가하였다.