### PR TITLE
#96 로그아웃 버튼 오류

### DIFF
--- a/src/commons/cookies/cookie.ts
+++ b/src/commons/cookies/cookie.ts
@@ -11,6 +11,11 @@ export const getCookie = (name: string) => {
   return cookies.get(name);
 };
 //쿠키를 지울때
-export const removeCookie = (name: string) => {
-  return cookies.remove(name);
+export const removeCookie = (name: string, options?: any) => {
+  return cookies.remove(name, {
+    path: "/",
+    secure: true,
+    sameSite: "none",
+    ...options,
+  });
 };


### PR DESCRIPTION
- 토큰 삭제부에서 소셜로그인에서 토큰을 저장할때 주었던 옵션값을 주었음

- path: "/", secure: true, sameSite:"none"