### PR TITLE
#110 프로필 변경시 리렌더 로직 추가

### DIFF
--- a/src/commons/profile_image/profile_image.tsx
+++ b/src/commons/profile_image/profile_image.tsx
@@ -90,7 +90,7 @@ const imageList = [
   { id: 6, name: "red" },
 ];
 
-export default function ImageUpload() {
+export default function ImageUpload(props: any) {
   const [selectedProfile, setSelectedProfile] = useState(0);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [croppedImage, setCroppedImage] = useState<Blob | null>(null);
@@ -123,8 +123,11 @@ export default function ImageUpload() {
             },
           }
         );
-        console.log("Upload successful:", response.data);
-        alert("프로필 기본 이미지 변경 정상완료!");
+        if (response.status === 200) {
+          console.log("Upload successful:", response.data);
+          alert("프로필 기본 이미지 변경 정상완료!");
+          props.closeModal();
+        }
       } catch (error) {
         console.error("Upload failed:", error);
       }
@@ -188,8 +191,11 @@ export default function ImageUpload() {
           },
         }
       );
-      console.log("Upload successful:", response.data);
-      alert("프로필 커스텀 이미지 변경 정상완료!");
+      if (response.status === 200) {
+        console.log("Upload successful:", response.data);
+        alert("프로필 커스텀 이미지 변경 정상완료!");
+        props.closeModal();
+      }
     } catch (error) {
       console.error("Upload failed:", error);
     }

--- a/src/commons/profile_image/profile_modal.tsx
+++ b/src/commons/profile_image/profile_modal.tsx
@@ -60,7 +60,8 @@ export default function Profile_Modal(props: any) {
           <h2>프로필 이미지 변경</h2>
           <CustomButton onClick={props.closeModal}>닫기</CustomButton>
         </Row_box>
-        <ImageUpload /> {/* ImageUpload 컴포넌트 */}
+        <ImageUpload closeModal={props.closeModal} />{" "}
+        {/* ImageUpload 컴포넌트 */}
       </Modal>
     </div>
   );

--- a/src/components/units/profile/profile_container.tsx
+++ b/src/components/units/profile/profile_container.tsx
@@ -50,6 +50,10 @@ export default function ProfileContainer() {
   const [userData, setUserData] = useState<IData | null>(null);
   const [userData2, setUserData2] = useState<IData2 | null>(null);
   const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
 
   const FETCH_PROFILE = async () => {
     try {
@@ -96,6 +100,11 @@ export default function ProfileContainer() {
     FETCH_USER();
   }, []);
 
+  useEffect(() => {
+    FETCH_PROFILE();
+    FETCH_USER();
+  }, [isModalOpen]);
+
   return (
     <Profile_UI
       data={userData}
@@ -103,6 +112,9 @@ export default function ProfileContainer() {
       onClickMyReview={onClickMyReview}
       onClickMyWrite={onClickMyWrite}
       onClickMyScrap={onClickMyScrap}
+      isModalOpen={isModalOpen}
+      openModal={openModal}
+      closeModal={closeModal}
     />
   );
 }

--- a/src/components/units/profile/profile_presenter.tsx
+++ b/src/components/units/profile/profile_presenter.tsx
@@ -157,11 +157,6 @@ const tv_genres = [
 ];
 
 export default function Profile_UI(props: IProfileProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
-
   const authProvider = AuthArray.find(
     (auth) => auth.key === props?.data2?.auth_provider
   );
@@ -178,7 +173,7 @@ export default function Profile_UI(props: IProfileProps) {
     <>
       <S.Wrapper>
         <S.RowWrapper>
-          <S.ImgBox onClick={openModal}>
+          <S.ImgBox onClick={props.openModal}>
             <S.Profile_image
               src={`https://imad-image-s3.s3.ap-northeast-2.amazonaws.com/profile/${props?.data?.user_profile_image}`}
               className="profile_img"
@@ -191,10 +186,9 @@ export default function Profile_UI(props: IProfileProps) {
             />
           </S.ImgBox>
           <Profile_Modal
-            isModalOpen={isModalOpen}
-            setIsModalOpen={setIsModalOpen}
-            openModal={openModal}
-            closeModal={closeModal}
+            isModalOpen={props.isModalOpen}
+            openModal={props.openModal}
+            closeModal={props.closeModal}
           />
 
           <S.ColumnWrapper>

--- a/src/components/units/profile/profile_types.ts
+++ b/src/components/units/profile/profile_types.ts
@@ -47,4 +47,7 @@ export interface IProfileProps {
   onClickMyReview: () => void;
   onClickMyWrite: () => void;
   onClickMyScrap: () => void;
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
 }


### PR DESCRIPTION
- 모달창을 띄워 프로필을 성공적으로 변경한 이후엔 alert 메시지로 프로필 사진 변경이 성공했음을 유저에게 알리게함

-alert 메시지 출력후 자동적으로 modal 창이 종료되며 modal 창 종료가 감지되면 화면이 리렌더 되어 자신이 변경한 이후의 프로필 사진을 확인 할수 있도록하는 로직을 추가함