### PR TITLE
#111 로그인 시도시 로그인 완료 페이지가 아닌 로그인 이전 페이지로 리다이렉트

### DIFF
--- a/pages/oauth2/redirect/success/index.tsx
+++ b/pages/oauth2/redirect/success/index.tsx
@@ -6,6 +6,7 @@ import axios from "axios";
 
 export default function KakaoRedirect(): JSX.Element {
   const router = useRouter();
+  const redirectUrl = router.query.origin_site;
 
   // 유저 정보 불러오기
   const PATCHUSER = async () => {
@@ -22,7 +23,7 @@ export default function KakaoRedirect(): JSX.Element {
             router.push("/user/edit");
           } else if (res.data.data.role === "USER") {
             console.log(res.data.data.role);
-            router.push("/user");
+            router.push(String(redirectUrl));
           }
         }
 

--- a/src/commons/layout/navigation/navigation.presenter.tsx
+++ b/src/commons/layout/navigation/navigation.presenter.tsx
@@ -2,12 +2,20 @@ import { Fragment } from "react";
 import * as S from "./navigation.styles";
 import { INavigationUIProps } from "./navigation.types";
 import { getCookie } from "../../cookies/cookie";
+import { useRouter } from "next/router";
 const NAVIGATION_MENUS = [
   { name: "게시판", page: "/board" },
   { name: "작품 검색", page: "/search" },
   { name: "캘린더", page: "/calendar" },
 ];
 export default function NavigationUI(props: INavigationUIProps): JSX.Element {
+  const router = useRouter(); // useRouter 사용
+
+  const handleLoginClick = () => {
+    const currentUrl = router.asPath; // 현재 URL 경로 가져오기
+    router.push(`/login?redirect=${encodeURIComponent(currentUrl)}`);
+  };
+
   return (
     <S.Wrapper>
       <S.Logo
@@ -36,7 +44,7 @@ export default function NavigationUI(props: INavigationUIProps): JSX.Element {
           로그아웃
         </S.MenuItem>
       ) : (
-        <S.MenuItem id="/login" onClick={props.onClickMenu}>
+        <S.MenuItem id="/login" onClick={handleLoginClick}>
           로그인
         </S.MenuItem>
       )}

--- a/src/components/units/login/login_container.tsx
+++ b/src/components/units/login/login_container.tsx
@@ -11,6 +11,8 @@ export default function LoginContainer() {
   const [password, setPassword] = useState("");
 
   const router = useRouter();
+  const redirectUrl = router.query.redirect || "/"; // 쿼리에서 redirect 값을 가져오거나 기본값 설정
+
   const LOGINIMAD = async () => {
     await axios
       .post("https://api.iimad.com/api/login", {
@@ -27,7 +29,7 @@ export default function LoginContainer() {
             sameSite: "none",
           });
           if (process.browser) {
-            router.push("/user");
+            router.push(String(redirectUrl));
           }
         }
 
@@ -67,19 +69,19 @@ export default function LoginContainer() {
 
   //소셜로그인 선택부
   const onClickLoginKakao = async () => {
-    window.location.href = `https://api.iimad.com/oauth2/authorization/kakao?redirect_uri=https://iimad.com/oauth2/redirect`;
+    window.location.href = `https://api.iimad.com/oauth2/authorization/kakao?redirect_uri=https://iimad.com/oauth2/redirect&origin_site=${redirectUrl}`;
   };
 
   const onClickLoginGoogle = async () => {
-    window.location.href = `https://api.iimad.com/oauth2/authorization/google?redirect_uri=https://iimad.com/oauth2/redirect`;
+    window.location.href = `https://api.iimad.com/oauth2/authorization/google?redirect_uri=https://iimad.com/oauth2/redirect&origin_site=${redirectUrl}`;
   };
 
   const onClickLoginNaver = async () => {
-    window.location.href = `https://api.iimad.com/oauth2/authorization/naver?redirect_uri=https://iimad.com/oauth2/redirect`;
+    window.location.href = `https://api.iimad.com/oauth2/authorization/naver?redirect_uri=https://iimad.com/oauth2/redirect&origin_site=${redirectUrl}`;
   };
 
   const onClickLoginApple = async () => {
-    window.location.href = `https://api.iimad.com/oauth2/login/apple?redirect_uri=https://iimad.com/oauth2/redirect`;
+    window.location.href = `https://api.iimad.com/oauth2/login/apple?redirect_uri=https://iimad.com/oauth2/redirect&origin_site=${redirectUrl}`;
   };
 
   return (


### PR DESCRIPTION
- 기존엔 어느 페이지에서 로그인을 시도하던 로그인 성공시 로그인 성공 페이지로 이동해 기존까지의 유저가 이동한 페이지가 날라가는 문제가 있었다.

- 이를 해결하기위해 로그인 버튼을 클릭시 클릭한 시점의 페이지 url 을 기록하고 login  페이지에 query 로 넘겨주기로 하였다.

- 일반로그인 성공시엔 로그인 성공 페이지 대신 기존 url 로 로그인이 성공된채로 이동하게 된다.

- 소셜로그인 시에는 소셜로그인의 redirectUrl 쿼리 뒤에 새로운 origin_site 라는 쿼리를 새로붙여 서버에서 처리후 origin_site 라는  쿼리가 붙은채로 리다이렉트 페이지로 이동하게 된다

- 소셜로그인 리다이렉트후 쿼리에 담겨진 토큰의 쿠키 처리가 끝나게되면 기존처럼 petch user 시퀀스가 실행되게 되고 신규유저가아닌 기존유저임이 확인되면 이후 origin_site의 url로 리다이렉트 되도록 설계하였다.

- 소셜로그인은 빌드 버젼에서 테스트 해야함으로 빌드후 테스트 예정