### PR TITLE
#184 페이지 이동시 스크롤이 초기화 되지 않는 버그 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  experimental: {
+    scrollRestoration: false,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,30 @@
 import { Global } from "@emotion/react";
 import Layout from "../src/commons/layout";
 import type { AppProps } from "next/app";
-import { BrowserRouter, Routes } from "react-router-dom";
 import { globalStyles } from "../src/commons/styles/globalStyles";
+import { useRouter } from "next/router";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      window.scrollTo(0, 0); // 스크롤을 최상단으로 이동
+    };
+
+    router.events.on("routeChangeComplete", handleRouteChange);
+
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange); // 이벤트 해제
+    };
+  }, [router.events]);
+
   return (
     <>
       <Global styles={globalStyles} />
-
       <Layout>
-        <Component {...pageProps}></Component>
+        <Component {...pageProps} />
       </Layout>
     </>
   );

--- a/src/commons/scrolltop/scrolltop.tsx
+++ b/src/commons/scrolltop/scrolltop.tsx
@@ -1,3 +1,5 @@
+// ScrollToTop.js
+
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 

--- a/src/commons/styles/globalStyles.ts
+++ b/src/commons/styles/globalStyles.ts
@@ -27,7 +27,7 @@ export const globalStyles = css`
     height: 100%;
     max-width: 100vw;
     min-height: 100vh;
-    overflow-x: hidden;
+
     font-family: "myfont", sans-serif;
     color: #333;
     background-color: #f5f5f5;

--- a/src/components/units/main/main.styles.ts
+++ b/src/components/units/main/main.styles.ts
@@ -9,6 +9,7 @@ export const Wrapper = styled.div`
   width: 100%;
   max-width: 100vw;
   height: 100%;
+  overflow-x: hidden;
 `;
 
 export const RowBox = styled.div`


### PR DESCRIPTION
- 페이지를 이동시에 이전페이지의 스크롤 상태가 다음페이지에도 똑같이 적용되 스크롤이 내려가 있는상태에서 화면이 렌더링되는 버그가 있었다.

- 이는 apps.tsx 에서 초기화 함수를 집어넣으면 단순히 해결되는 간단한  문제였지만 나는 해결이 되지않았다.

- 원인을 찾아보니 이는 전역 css 설정인 globalcss  파일에서  html,body 부분에 overflow-x ,y 가 설정되어있었기 때문이다 이는 화면구성초기에 설정한것이지만 딱히 바꿀이유가 없었던 설정이여서 건들지않았지만 이것이 함수와 충돌을 일으켜 scrollto 기능이 작동을 하지않았던것이었다.