### PR TITLE
#111 스크롤 버그의 추가해결과  메인배너의 수정

### DIFF
--- a/src/commons/styles/globalStyles.ts
+++ b/src/commons/styles/globalStyles.ts
@@ -21,13 +21,15 @@ export const globalStyles = css`
   }
 
   /* HTML과 BODY 설정 */
-  html,
+  html {
+    overflow-x: hidden; /* 가로 스크롤 방지 */
+    width: 100%;
+    height: 100%;
+  }
+
   body {
     width: 100%;
     height: 100%;
-    max-width: 100vw;
-    min-height: 100vh;
-
     font-family: "myfont", sans-serif;
     color: #333;
     background-color: #f5f5f5;

--- a/src/components/units/main/main.presenter.tsx
+++ b/src/components/units/main/main.presenter.tsx
@@ -76,10 +76,12 @@ export default function MainPageUI(props: IMainProps): JSX.Element {
 
   const settings = {
     dots: true,
-    infinite: false,
+    infinite: true,
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
+    autoplay: true, // 자동으로 슬라이드 넘기기
+    autoplaySpeed: 5000, // 2초마다 넘기기
     nextArrow: (
       <S.NextTo>
         <S.Arrow src="/img/icon/next.png" />
@@ -224,14 +226,14 @@ export default function MainPageUI(props: IMainProps): JSX.Element {
                   <S.ImgBox
                     key={"title" in el ? el.title : el.name}
                     url={`https://image.tmdb.org/t/p/original/${el.poster_path}`}
-                    onClick={() =>
-                      category === "movie"
-                        ? props.onClickMovieContents(el.id)
-                        : props.onClickTvContents(el.id)
-                    }
                   >
                     <S.MainSliderItem
                       src={`https://image.tmdb.org/t/p/original/${el.poster_path}`}
+                      onClick={() =>
+                        category === "movie"
+                          ? props.onClickMovieContents(el.id)
+                          : props.onClickTvContents(el.id)
+                      }
                     />
                   </S.ImgBox>
                   <S.MainBannerTitle

--- a/src/components/units/main/main.styles.ts
+++ b/src/components/units/main/main.styles.ts
@@ -7,9 +7,6 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 100vw;
-  height: 100%;
-  overflow-x: hidden;
 `;
 
 export const RowBox = styled.div`
@@ -133,7 +130,7 @@ export const GridBox = styled.div`
   gap: 30px; /* 아이템 간의 간격 */
   grid-auto-flow: column;
 
-  @media (max-width: 768px) {
+  @media (max-width: 1080px) {
     overflow-x: auto; /* 가로 스크롤 활성화 */
 
     gap: 10px; /* 아이템 간격 줄이기 */
@@ -207,6 +204,7 @@ export const MergedChartWrapper = styled.div`
   margin-left: 10%;
   margin-right: 10%;
   margin-top: 5%;
+  overflow-x: auto;
 
   @media (max-width: 480px) {
     width: 100%;
@@ -637,8 +635,8 @@ export const SubBannerWrapper = styled.div`
 
 export const MainBannerWrapper = styled.div`
   background-color: #666;
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
+
   height: 600px;
 
   @media (max-width: 480px) {
@@ -795,7 +793,6 @@ export const BackgroundImageWrapper = styled.div<{ backgroundUrl: string }>`
 `;
 
 export const MainBannerBox = styled.div`
-  overflow: hidden;
   height: 590px;
 
   @media (max-width: 480px) {
@@ -828,23 +825,32 @@ export const BannerBox = styled.div`
 `;
 
 export const Arrow = styled.img`
-  width: 100%;
-  height: 100%;
+  width: 30px;
+  height: 30px;
+
+  position: absolute;
+  top: 50%;
 `;
 
 export const Pre = styled.div`
-  width: 30px;
-  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 100%;
   position: absolute;
-  left: 3%;
+  left: 0px;
   z-index: 3;
 `;
 
 export const NextTo = styled.div`
-  width: 30px;
-  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 100%;
   position: absolute;
-  right: 3%;
+  right: 0px;
   z-index: 3;
 `;
 


### PR DESCRIPTION
- 메인배너의 수정:
1. 메인배너의 사이드 버튼 작동범위가 너무 작다는 의견을 수렴 사이드버튼의 범위를 가로를 10px정도씩 늘리고 이상태로 세로 길이를 배너의 전체로 수정

2. 메인배너의 배경을 클릭해도 작품상세페이지로 연결되는 문제 해결 작품의 포스터를 클릭시에만 이동하도록 변경

- 스크롤설정의 문제
1. 페이지 이동시 스크롤을 상단부로 초기화 시키기위해 globalcss 쪽에서 overflow 설정을 삭제하였지만 이를 삭제하니 페이지들마다 불필요한 가로 스크롤이 생성됨

2. 이를 해결하기위해 글로벌 설정에서 /* HTML과 BODY 설정 */
  html {
    overflow-x: hidden; /* 가로 스크롤 방지 */
    width: 100%;
    height: 100%;
  }

  body {
    width: 100%;
    height: 100%;
    font-family: "myfont", sans-serif;
    color: #333;
    background-color: #f5f5f5;
  } 이와 같이 html 설정부와 body 설정부를 분리 이를 통해 기존의 스크롤 초기화 기능을 유지한채로 불필요한 스크롤바를 없앨수있었음