### PR TITLE
#113 메인 화면 모바일 접속시 가로스크롤 발생 버그 수정

### DIFF
--- a/src/components/units/main/main.styles.ts
+++ b/src/components/units/main/main.styles.ts
@@ -8,6 +8,10 @@ export const Wrapper = styled.div`
   flex-direction: column;
   width: 100%;
   min-width: 100vw;
+
+  @media (max-width: 480px) {
+    overflow-x: hidden;
+  }
 `;
 
 export const RowBox = styled.div`


### PR DESCRIPTION
- 메인화면을 모바일에서 접속시 쓸대없는 가로스크롤이 생기는 버그를 발견했다.

- 이를 해결하기위해 기존처럼 globalstyles 가아닌 main-styles wrapper 에 overflow-x : hidden 속성을 추가하였더니 스크롤 탑은 정상작동하며 가로스크롤만 깔끔하게 사라진것을 확인하였다.