### PR TITLE
서버 분리로 인한 api 요청 url 변경

### DIFF
--- a/api/apiClient.ts
+++ b/api/apiClient.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/commons/cookies/cookie"; // 쿠키 유틸리티
 
 const apiClient = axios.create({
-  baseURL: "https://api.iimad.com", // 기본 API URL 설정
+  baseURL: "https://api.imad.ncookie.net", // 기본 API URL 설정
   headers: {
     "Content-Type": "application/json", // 기본 헤더 설정
   },

--- a/src/components/units/login/login_container.tsx
+++ b/src/components/units/login/login_container.tsx
@@ -26,7 +26,7 @@ export default function LoginContainer() {
     }
 
     await axios
-      .post("https://api.iimad.com/api/login", {
+      .post("https://api.imad.ncookie.net/api/login", {
         email: email,
         password: SHA256(password).toString(),
       })


### PR DESCRIPTION
- 서버 요청 url 이 api.iimad.com 에서 api.imad.ncookie.net으로 변경됨에 따라 통합 api 관리 컴포넌트에서 url을 변경함

- 별도로 axios를 사용중인 로그인 컴포넌트의 url도 변경됨

- 이후 서버측의 s3도 변경됨에 따라 이미지를 불러오는 url도 변경될 예정